### PR TITLE
fix: mentions will load people in the comments first

### DIFF
--- a/lib/cubits/comment/comment_cubit.dart
+++ b/lib/cubits/comment/comment_cubit.dart
@@ -94,6 +94,15 @@ class CommentCubit extends Cubit<CommentState> {
     if (mentionedUserName == null) {
       emit(CommentsLoaded(_comments));
       return;
+    } else if (mentionedUserName == '@') {
+      final myUserId = _repository.userId;
+      final usersInComments = _comments
+          .where((comment) => comment.user.id != myUserId)
+          .map((comment) => comment.user)
+          .take(2)
+          .toList();
+      emit(CommentsLoaded(_comments, mentionSuggestions: usersInComments));
+      return;
     }
     emit(CommentsLoaded(_comments, isLoadingMentions: true));
     final mentionSuggestions = await _repository.getMentions(mentionedUserName);

--- a/lib/cubits/confirm_video/confirm_video_cubit.dart
+++ b/lib/cubits/confirm_video/confirm_video_cubit.dart
@@ -15,8 +15,6 @@ import 'package:video_player/video_player.dart';
 
 part 'confirm_video_state.dart';
 
-// ignore_for_file: lines_longer_than_80_chars
-
 class ConfirmVideoCubit extends Cubit<ConfirmVideoState> {
   ConfirmVideoCubit({required Repository repository})
       : _repository = repository,

--- a/lib/repositories/repository.dart
+++ b/lib/repositories/repository.dart
@@ -722,7 +722,7 @@ class Repository {
     final res = await _supabaseClient
         .from('users')
         .select()
-        .like('name', '%$queryString%')
+        .ilike('name', '%$queryString%')
         .limit(2)
         .execute();
     final error = res.error;
@@ -779,7 +779,7 @@ class Repository {
     }
     final mentionedUserName = mention.substring(1);
     if (mentionedUserName.isEmpty) {
-      return null;
+      return '@';
     }
     return mentionedUserName;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -636,7 +636,7 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.7"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -664,7 +664,7 @@ packages:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   shared_preferences_windows:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spot
 description: Find local video posts
-version: 1.1.7+45
+version: 1.1.8+46
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Description

When entering `@` in the comment window, it will bring up list of users that have commented as suggestion. 

Closes https://github.com/dshukertjr/spot/issues/33

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
